### PR TITLE
Make tryorama Lair-keystore aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An end-to-end/scenario testing framework for Holochain applications, written in 
 
 Tryorama allows you to write test suites about the behavior of multiple Holochain nodes which are networked together, while ensuring that test nodes in different tests do not accidentally join a network together.
 
-Note: this version of tryorama is tested against holochain rev 60a906212c17ee067b31511e6b2957746d86297b.  Please see [testing Readme](test/README.md) for details on how to run tryorama's own tests.
+Note: this version of tryorama is tested against holochain rev afdb4e949b77cc81afa1b0601cf406dc08587b45.  Please see [testing Readme](test/README.md) for details on how to run tryorama's own tests.
 
 ```bash
 npm install @holochain/tryorama

--- a/ci_scripts/install-holochain.sh
+++ b/ci_scripts/install-holochain.sh
@@ -9,6 +9,6 @@ cargo install --force holochain \
 cargo install --force dna_util \
   --git https://github.com/holochain/holochain.git \
   --rev $REV
-cargo install --force lair-keystore \
+cargo install --force lair_keystore \
   --git https://github.com/holochain/lair.git \
   --rev $LAIR_REV

--- a/ci_scripts/install-holochain.sh
+++ b/ci_scripts/install-holochain.sh
@@ -8,3 +8,5 @@ cargo install --force holochain \
 cargo install --force dna_util \
   --git https://github.com/holochain/holochain.git \
   --rev $REV
+cargo install --force lair-keystore \
+      --git https://github.com/holochain/lair.git

--- a/ci_scripts/install-holochain.sh
+++ b/ci_scripts/install-holochain.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-REV=60a906212c17ee067b31511e6b2957746d86297b
+REV=afdb4e949b77cc81afa1b0601cf406dc08587b45
+LAIR_REV=be5868e6dcbe99c795a101c0e27ba6ed5edd557d
 
 cargo install --force holochain \
   --git https://github.com/holochain/holochain.git \
@@ -9,4 +10,5 @@ cargo install --force dna_util \
   --git https://github.com/holochain/holochain.git \
   --rev $REV
 cargo install --force lair-keystore \
-      --git https://github.com/holochain/lair.git
+  --git https://github.com/holochain/lair.git \
+  --rev $LAIR_REV

--- a/src/config/gen.ts
+++ b/src/config/gen.ts
@@ -16,10 +16,12 @@ export const gen = ( commonConfig: T.CommonConfig = {} ): T.ConfigSeed => (
   args: T.ConfigSeedArgs
 ): T.RawConductorConfig => {
   const { configDir, adminInterfacePort, uuid } = args
+  const keystorePath = path.join(configDir, 'keystore');
   
   // don't put any keys on this object that you want to fall back to defaults
   const specific: T.RawConductorConfig = {
     environment_path: configDir,
+    keystore_path: keystorePath, 
     admin_interfaces: [
       {
         driver: {

--- a/src/config/spawn.ts
+++ b/src/config/spawn.ts
@@ -28,6 +28,17 @@ export const spawnLocal: T.SpawnConductorFn = async (player: Player, { handleHoo
   const configPath = getConfigPath(player._configDir)
   let handle
   try {
+
+    logger.info("Spawining lair for test with keystore at:  %s", `${configPath}/keystore`)
+
+    spawn("lair-keystore", ["-d", `${configPath}/keystore`], {
+      env: {
+        // TODO: maybe put this behind a flag?
+        "RUST_BACKTRACE": "1",
+        ...process.env,
+      }
+    })
+
     const binPath = env.holochainPath
     const version = execSync(`${binPath} --version`)
     logger.info("Using conductor path:  %s", binPath)

--- a/src/config/spawn.ts
+++ b/src/config/spawn.ts
@@ -27,11 +27,15 @@ export const spawnLocal: T.SpawnConductorFn = async (player: Player, { handleHoo
   const name = player.name
   const configPath = getConfigPath(player._configDir)
   let handle
+  let lairHandle
   try {
 
-    logger.info("Spawining lair for test with keystore at:  %s", `${configPath}/keystore`)
-
-    spawn("lair-keystore", ["-d", `${configPath}/keystore`], {
+    const lairDir = `${configPath}/keystore`
+    if (!fs.existsSync(lairDir)){
+      fs.mkdirSync(lairDir);
+    }
+    logger.info("Spawining lair for test with keystore at:  %s", lairDir)
+    lairHandle = spawn("lair-keystore", ["-d", lairDir], {
       env: {
         // TODO: maybe put this behind a flag?
         "RUST_BACKTRACE": "1",
@@ -73,6 +77,7 @@ export const spawnLocal: T.SpawnConductorFn = async (player: Player, { handleHoo
       player,
       name,
       kill: async (...args) => {
+        lairHandle.kill()
         // wait for it to be finished off before resolving
         const killPromise = new Promise((resolve) => {
           handle.once('close', resolve)

--- a/src/config/spawn.ts
+++ b/src/config/spawn.ts
@@ -9,6 +9,8 @@ import { getConfigPath } from ".";
 import { trycpSession, TrycpClient } from "../trycp";
 import { delay } from "../util";
 import env from '../env'
+var fs = require('fs');
+
 
 export const spawnTest: T.SpawnConductorFn = async (player: Player, { }) => {
   return new Conductor({
@@ -30,18 +32,19 @@ export const spawnLocal: T.SpawnConductorFn = async (player: Player, { handleHoo
   let lairHandle
   try {
 
-    const lairDir = `${configPath}/keystore`
+    const lairDir = `${player._configDir}/keystore`
     if (!fs.existsSync(lairDir)){
       fs.mkdirSync(lairDir);
     }
     logger.info("Spawining lair for test with keystore at:  %s", lairDir)
-    lairHandle = spawn("lair-keystore", ["-d", lairDir], {
+    lairHandle = await spawn("lair-keystore", ["-d", lairDir], {
       env: {
         // TODO: maybe put this behind a flag?
         "RUST_BACKTRACE": "1",
         ...process.env,
       }
     })
+    await delay(500)
 
     const binPath = env.holochainPath
     const version = execSync(`${binPath} --version`)

--- a/src/config/spawn.ts
+++ b/src/config/spawn.ts
@@ -36,7 +36,7 @@ export const spawnLocal: T.SpawnConductorFn = async (player: Player, { handleHoo
     if (!fs.existsSync(lairDir)){
       fs.mkdirSync(lairDir);
     }
-    logger.info("Spawining lair for test with keystore at:  %s", lairDir)
+    logger.info("Spawning lair for test with keystore at:  %s", lairDir)
     const lairBinPath = env.lairPath
     lairHandle = await spawn(lairBinPath, ["-d", lairDir], {
       env: {

--- a/src/config/spawn.ts
+++ b/src/config/spawn.ts
@@ -37,7 +37,8 @@ export const spawnLocal: T.SpawnConductorFn = async (player: Player, { handleHoo
       fs.mkdirSync(lairDir);
     }
     logger.info("Spawining lair for test with keystore at:  %s", lairDir)
-    lairHandle = await spawn("lair-keystore", ["-d", lairDir], {
+    const lairBinPath = env.lairPath
+    lairHandle = await spawn(lairBinPath, ["-d", lairDir], {
       env: {
         // TODO: maybe put this behind a flag?
         "RUST_BACKTRACE": "1",

--- a/src/config/spawn.ts
+++ b/src/config/spawn.ts
@@ -81,11 +81,15 @@ export const spawnLocal: T.SpawnConductorFn = async (player: Player, { handleHoo
       player,
       name,
       kill: async (...args) => {
-        lairHandle.kill()
         // wait for it to be finished off before resolving
-        const killPromise = new Promise((resolve) => {
+        const conductorKillPromise = new Promise((resolve) => {
           handle.once('close', resolve)
         })
+        const lairKillPromise = new Promise((resolve) => {
+          lairHandle.once('close', resolve)
+        })
+        const killPromise = Promise.all([conductorKillPromise,lairKillPromise])
+        lairHandle.kill()
         handle.kill(...args)
         return killPromise
       },

--- a/src/env.ts
+++ b/src/env.ts
@@ -18,7 +18,7 @@ const bool = Boolean
 
 const legacy = bool(process.env['TRYORAMA_LEGACY'] || false)
 const defaultHolochainPath = 'holochain'
-const defaultLairPath = 'lair-keystre'
+const defaultLairPath = 'lair-keystore'
 const interfaceIdPrefix = process.env['TRYORAMA_INTERFACE_ID'] || 'tryorama-interface'
 
 const VARS = {

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,4 +1,3 @@
-
 const int = (n) => {
   try {
     return parseInt(n, 10)
@@ -19,6 +18,7 @@ const bool = Boolean
 
 const legacy = bool(process.env['TRYORAMA_LEGACY'] || false)
 const defaultHolochainPath = 'holochain'
+const defaultLairPath = 'lair-keystre'
 const interfaceIdPrefix = process.env['TRYORAMA_INTERFACE_ID'] || 'tryorama-interface'
 
 const VARS = {
@@ -34,7 +34,8 @@ const VARS = {
   portRange: [33000, 34000],  // not hooked up to env var yet
   legacy,
   singletonAppId: 'TRYORAMA_APP',
-  holochainPath: process.env.TRYORAMA_HOLOCHAIN_PATH || defaultHolochainPath
+  holochainPath: process.env.TRYORAMA_HOLOCHAIN_PATH || defaultHolochainPath,
+  lairPath: process.env.TRYORAMA_LAIR_PATH || defaultLairPath
 }
 
 

--- a/test/e2e/fixture/zomes/test/Cargo.toml
+++ b/test/e2e/fixture/zomes/test/Cargo.toml
@@ -9,6 +9,6 @@ name = "test_wasm"
 crate-type = [ "cdylib", "rlib" ]
 
 [dependencies]
-hdk3 = { git = "https://github.com/holochain/holochain", rev = "60a906212c17ee067b31511e6b2957746d86297b", package = "hdk3" }
+hdk3 = { git = "https://github.com/holochain/holochain", rev = "afdb4e949b77cc81afa1b0601cf406dc08587b45", package = "hdk3" }
 serde = "1.0.104"
-test_wasm_common = { git = "https://github.com/holochain/holochain", rev = "60a906212c17ee067b31511e6b2957746d86297b", package = "test_wasm_common" }
+test_wasm_common = { git = "https://github.com/holochain/holochain", rev = "afdb4e949b77cc81afa1b0601cf406dc08587b45", package = "test_wasm_common" }


### PR DESCRIPTION
Adds lair-keystore awareness to tryorama:
- explicitly spawns and kills an instance of lair-keystore along with each conductor instance being spawned.