### PR TITLE
Fix/conductor logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 ### Fixed
 
+## [0.5.6]
+
+### Fixed
+- Local conductor: subscribe to all messages to stderr. [PR \#125](https://github.com/holochain/tryorama/pull/125)
+- Local conductor: log as info instead of as error. [PR \#125](https://github.com/holochain/tryorama/pull/125)
+
 ## [0.5.5]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -127,15 +127,15 @@ all conductors involved in the test scenario.
 When writing the test, it might be necessary to handle errors while developing,
 depending on the test runner. With a test runner like "tape", uncaught errors
 will cause the conductor process and therefore the test to hang or output
-`[object Object]`` as the only error message. If you're facing this issue, you
-can treat errors like this:
+`[object Object]` as the only error message. In this case errors can be handled
+like this:
 
 ```ts
 const scenario = new LocalScenario();
 try {
-  /* operations with the scenario */
+  /* scenario operations */
 } catch (error) {
-  console.error("an error occurred during the test", error);
+  console.error("error occurred during test", error);
 } finally (
   await scenario.cleanUp()
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@holochain/tryorama",
   "description": "Toolset to manage Holochain conductors and facilitate running test scenarios",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "author": "Holochain Foundation",
   "keywords": [
     "holochain",

--- a/ts/src/local/conductor.ts
+++ b/ts/src/local/conductor.ts
@@ -270,8 +270,8 @@ export class Conductor implements IConductor {
         }
       });
 
-      runConductorProcess.stderr.once("data", (data: Buffer) => {
-        logger.error(`starting conductor: ${data.toString()}`);
+      runConductorProcess.stderr.on("data", (data: Buffer) => {
+        logger.info(data.toString());
       });
     });
     await startPromise;


### PR DESCRIPTION
### Fixed

- Local conductor: subscribe to all messages to stderr.
- Local conductor: log as info instead of as error.

fixes #124 