### PR TITLE
Feat/add timeout to zome call

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Check out source code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install nix
       uses: cachix/install-nix-action@v16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 ### Fixed
 
+## [0.5.7]
+
+### Added
+- Common: optional timeout for zome calls [PR \#130](https://github.com/holochain/tryorama/pull/130)
+
+### Fixed
+- Local conductor: log conductor startup only once and at correct moment [PR \#130](https://github.com/holochain/tryorama/pull/130)
+
 ## [0.5.6]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -141,6 +141,17 @@ try {
 }
 ```
 
+### Logging
+
+The log level can be set with the environment variable `TRYORAMA_LOG_LEVEL`.
+Log levels used in Tryorama are `debug`, `verbose` and `info`. The default
+level is `info`. To set the log level for a test run, prepend the test command
+with:
+
+```bash
+TRYORAMA_LOG_LEVEL=debug node test.js
+```
+
 ## Concepts
 
 [Scenarios](./docs/tryorama.scenario.md) provide high-level functions to

--- a/docs/tryorama.callzomefn.md
+++ b/docs/tryorama.callzomefn.md
@@ -9,7 +9,7 @@ The function for calling a zome from a specific cell.
 <b>Signature:</b>
 
 ```typescript
-export declare type CallZomeFn = <T>(request: CellZomeCallRequest) => Promise<T>;
+export declare type CallZomeFn = <T>(request: CellZomeCallRequest, timeout?: number) => Promise<T>;
 ```
 <b>References:</b> [CellZomeCallRequest](./tryorama.cellzomecallrequest.md)
 

--- a/docs/tryorama.getzomecaller.md
+++ b/docs/tryorama.getzomecaller.md
@@ -4,10 +4,10 @@
 
 ## getZomeCaller variable
 
-Get a shorthand function to call a Cell's Zome.
+Get a shorthand function to call a cell's zome.
 
 <b>Signature:</b>
 
 ```typescript
-getZomeCaller: (cell: CallableCell, zomeName: string) => <T>(fnName: string, payload?: unknown) => Promise<T>
+getZomeCaller: (cell: CallableCell, zomeName: string) => <T>(fnName: string, payload?: unknown, timeout?: number) => Promise<T>
 ```

--- a/docs/tryorama.md
+++ b/docs/tryorama.md
@@ -90,7 +90,7 @@ TryCP stands for Tryorama Control Protocol (TryCP) and is a protocol to enable r
 |  [createConductor](./tryorama.createconductor.md) | The function to create a conductor. It starts a sandbox conductor via the Holochain CLI. |
 |  [createTryCpConductor](./tryorama.createtrycpconductor.md) | The function to create a TryCP Conductor (aka "Player"). |
 |  [DEFAULT\_PARTIAL\_PLAYER\_CONFIG](./tryorama.default_partial_player_config.md) | The default partial config for a TryCP conductor. |
-|  [getZomeCaller](./tryorama.getzomecaller.md) | Get a shorthand function to call a Cell's Zome. |
+|  [getZomeCaller](./tryorama.getzomecaller.md) | Get a shorthand function to call a cell's zome. |
 |  [pause](./tryorama.pause.md) | A utility function to wait the given amount of time. |
 |  [runScenario](./tryorama.runscenario.md) | A wrapper function to create and run a scenario. A scenario is created and all involved conductors are shut down and cleaned up after running. |
 |  [TRYCP\_SUCCESS\_RESPONSE](./tryorama.trycp_success_response.md) | Empty success response. |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@holochain/tryorama",
   "description": "Toolset to manage Holochain conductors and facilitate running test scenarios",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "author": "Holochain Foundation",
   "keywords": [
     "holochain",

--- a/ts/src/common.ts
+++ b/ts/src/common.ts
@@ -81,23 +81,26 @@ const getCallableCell = (
   agentPubKey: AgentPubKey
 ) => ({
   ...cell,
-  callZome: async <T>(request: CellZomeCallRequest) => {
-    const callZomeResponse = await conductor.appWs().callZome({
-      ...request,
-      cap_secret: request.cap_secret ?? null,
-      cell_id: cell.cell_id,
-      provenance: request.provenance || agentPubKey,
-      payload: request.payload ?? null,
-    });
+  callZome: async <T>(request: CellZomeCallRequest, timeout?: number) => {
+    const callZomeResponse = await conductor.appWs().callZome(
+      {
+        ...request,
+        cap_secret: request.cap_secret ?? null,
+        cell_id: cell.cell_id,
+        provenance: request.provenance || agentPubKey,
+        payload: request.payload ?? null,
+      },
+      timeout
+    );
     assertZomeResponse<T>(callZomeResponse);
     return callZomeResponse;
   },
 });
 
 /**
- * Get a shorthand function to call a Cell's Zome.
+ * Get a shorthand function to call a cell's zome.
  *
- * @param cell - The Cell to call the Zome on.
+ * @param cell - The cell to call the zome on.
  * @param zomeName - The name of the Zome to call.
  * @returns A function to call the specified Zome.
  *
@@ -105,9 +108,12 @@ const getCallableCell = (
  */
 export const getZomeCaller =
   (cell: CallableCell, zomeName: string) =>
-  <T>(fnName: string, payload?: unknown): Promise<T> =>
-    cell.callZome<T>({
-      zome_name: zomeName,
-      fn_name: fnName,
-      payload,
-    });
+  <T>(fnName: string, payload?: unknown, timeout?: number): Promise<T> =>
+    cell.callZome<T>(
+      {
+        zome_name: zomeName,
+        fn_name: fnName,
+        payload,
+      },
+      timeout
+    );

--- a/ts/src/local/conductor.ts
+++ b/ts/src/local/conductor.ts
@@ -249,14 +249,12 @@ export class Conductor implements IConductor {
     );
     const startPromise = new Promise<void>((resolve) => {
       runConductorProcess.stdout.on("data", (data: Buffer) => {
-        logger.debug(`starting conductor\n${data}`);
-
         const numberMatches = data
           .toString()
           .match(/Running conductor on admin port (\d+)/);
         if (numberMatches) {
           this.adminApiUrl.port = numberMatches[1];
-          logger.debug(`admin port ${this.adminApiUrl.port}\n`);
+          logger.debug(`starting conductor\n${data}`);
         }
 
         if (

--- a/ts/src/types.ts
+++ b/ts/src/types.ts
@@ -31,7 +31,10 @@ export type CellZomeCallRequest = Omit<
  *
  * @public
  */
-export type CallZomeFn = <T>(request: CellZomeCallRequest) => Promise<T>;
+export type CallZomeFn = <T>(
+  request: CellZomeCallRequest,
+  timeout?: number
+) => Promise<T>;
 
 /**
  * Extends an installed cell by a function to call a zome.

--- a/ts/test/local/conductor.ts
+++ b/ts/test/local/conductor.ts
@@ -1,10 +1,11 @@
-import { HeaderHash } from "@holochain/client";
 import {
   AppSignal,
   AppSignalCb,
   DnaSource,
   EntryHash,
+  HeaderHash,
 } from "@holochain/client";
+import assert from "node:assert";
 import { readFileSync } from "node:fs";
 import { URL } from "node:url";
 import test from "tape-promise/tape.js";
@@ -248,6 +249,20 @@ test("Local Conductor - Install hApp bundle and access cells with role ids", asy
     path: FIXTURE_HAPP_URL.pathname,
   });
   t.ok(aliceHapp.namedCells.get("test"));
+
+  await conductor.shutDown();
+  await cleanAllConductors();
+});
+
+test("Local Conductor - Zome call can time out before completion", async (t) => {
+  const conductor = await createConductor();
+  const aliceHapp = await conductor.installHappBundle({
+    path: FIXTURE_HAPP_URL.pathname,
+  });
+  const cell = aliceHapp.namedCells.get("test");
+  assert(cell);
+
+  await t.rejects(cell.callZome({ fn_name: "create", zome_name: "crud" }, 1));
 
   await conductor.shutDown();
   await cleanAllConductors();


### PR DESCRIPTION
### Added
- Common: optional timeout for zome calls; fixes #129 

### Fixed
- Local conductor: log conductor startup only once and at correct moment #128 