### PR TITLE
runScenario: not fail silently

### DIFF
--- a/ts/src/local/scenario.ts
+++ b/ts/src/local/scenario.ts
@@ -194,8 +194,6 @@ export const runScenario = async (
   const scenario = new Scenario(options);
   try {
     await testScenario(scenario);
-  } catch (error) {
-    console.error("error occurred during test run:", error);
   } finally {
     if (cleanUp) {
       await scenario.cleanUp();


### PR DESCRIPTION
This is a suggestion. With the catch clause, my `vitest` tests were failing silently.  This will just let the test fail