### PR TITLE
feat: add helper util conductorCellsDhtSync -- alternative to dhtSync

### DIFF
--- a/ts/src/types.ts
+++ b/ts/src/types.ts
@@ -7,6 +7,7 @@ import type {
   AppSignalCb,
   AppWebsocket,
   CallZomeRequest,
+  CellId,
   ClonedCell,
   DnaBundle,
   DnaProperties,
@@ -199,4 +200,12 @@ export interface Dna {
   membraneProof?: MembraneProof;
   properties?: DnaProperties;
   roleName?: string;
+}
+
+/**
+ * A Conductor and a CellId
+ */
+export interface IConductorCell {
+  conductor: IConductor;
+  cellId: CellId;
 }


### PR DESCRIPTION
@jost-s I know we went back and forth on this api in #178. I now need a version of `dhtSync()` that takes in a conductor, rather than a player.

This adds duplicated functions `conductorCellDhtSync` and `isConductorCellDhtEqual` and makes the prior versions aliases to these.

They take in a `IConductorCell` which just wraps an `IConductor` and `CellId`.

It's not clear why, but the docs aren't building for me.