### PR TITLE
add a rust trycp client crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,16 +968,16 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "holo_hash"
-version = "0.4.0-dev.1"
+version = "0.4.0-dev.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439389b876b16eeddb280e4daf68002c8792103e40ed332bb9bef6a898f7a367"
+checksum = "80b84303db38ecc1c5a3b5334b3da34201cf04dc231b37e7fda01e418e160089"
 dependencies = [
  "base64",
  "blake2b_simd",
  "derive_more",
  "holochain_serialized_bytes",
  "holochain_util",
- "holochain_wasmer_common",
+ "holochain_wasmer_common 0.0.94",
  "kitsune_p2p_dht_arc",
  "serde",
  "serde_bytes",
@@ -986,9 +986,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_integrity_types"
-version = "0.4.0-dev.1"
+version = "0.4.0-dev.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c204c0e9f64f0c04e4980df7049e99dac459311d81298f352e1e2e38946ecf8"
+checksum = "c41780c1d157026b8730e45877960238a976f72bef3d832d14d2d6dc24716187"
 dependencies = [
  "holo_hash",
  "holochain_secure_primitive",
@@ -1003,9 +1003,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_nonce"
-version = "0.4.0-dev.1"
+version = "0.4.0-dev.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf025d865d391e4388e24382f8da70e13a4395348e5a250fa82051ae44b70c8"
+checksum = "b936fd7c76100863fb1ee4842d6f55d8d102e3bf836b89fc645019c064ae52a4"
 dependencies = [
  "getrandom",
  "holochain_secure_primitive",
@@ -1077,13 +1077,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "holochain_wasmer_common"
+version = "0.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9f7d17668e4a4997b5e121c7a951ea9606331ef206b991f1e81420c84d98485"
+dependencies = [
+ "holochain_serialized_bytes",
+ "serde",
+ "serde_bytes",
+ "test-fuzz",
+ "thiserror",
+ "wasmer",
+]
+
+[[package]]
 name = "holochain_wasmer_guest"
 version = "0.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10fcb10d7d455c5222a13b2343e2a438bcbbf3f97ef79f16c9e01203f6616dd0"
 dependencies = [
  "holochain_serialized_bytes",
- "holochain_wasmer_common",
+ "holochain_wasmer_common 0.0.93",
  "parking_lot",
  "paste",
  "serde",
@@ -1092,16 +1106,16 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
-version = "0.4.0-dev.1"
+version = "0.4.0-dev.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ab039f61375d1aa5b33de73971ae176775040e8aad8f65ec72cf274ce50b178"
+checksum = "8d4cf8e17e46f1ffc70d16f6f53b3c50ab730514f2485a25472218eb3a4fb35e"
 dependencies = [
  "derive_more",
  "holo_hash",
  "holochain_integrity_types",
  "holochain_nonce",
  "holochain_serialized_bytes",
- "holochain_wasmer_common",
+ "holochain_wasmer_common 0.0.94",
  "kitsune_p2p_block",
  "kitsune_p2p_timestamp",
  "serde",
@@ -1336,9 +1350,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_bin_data"
-version = "0.4.0-dev.1"
+version = "0.4.0-dev.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d7fbce2d113aaf0eb99076d5a77f3acb659350aef8dc76235de8a134f4ddbbf"
+checksum = "f0a6a1f169c55972780aecd280a2a4548a6fb1b55ff8c3039a8dfef50c4e2985"
 dependencies = [
  "base64",
  "derive_more",
@@ -1351,9 +1365,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_block"
-version = "0.4.0-dev.1"
+version = "0.4.0-dev.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5600ee3a3b4d282f87dddc24262640d9ee267621ae9f6f7eda8483f4e46b360"
+checksum = "88d374982ce2b07d4253ef7ecb9e2ec89d1e10e8e92c8aaba71d679684bc3abe"
 dependencies = [
  "kitsune_p2p_bin_data",
  "kitsune_p2p_timestamp",
@@ -1362,9 +1376,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_dht_arc"
-version = "0.4.0-dev.1"
+version = "0.4.0-dev.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a1c38460330340f036390bfe0aba67a4f0608635079439061b87c4a528bd8e"
+checksum = "894bc48429be17d4d2d57d71e5d117086f81e529f7d733d98882335f8e5bd2df"
 dependencies = [
  "derive_more",
  "gcollections",
@@ -1376,9 +1390,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_timestamp"
-version = "0.4.0-dev.0"
+version = "0.4.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504c201124264754c22e577db2184db79767cf47a63817f902a6a461e82d8cb8"
+checksum = "7edfdb7b15c5e5e3b706b986ec52faabdacab1bbbac7db32246734ef4d8d56ac"
 dependencies = [
  "chrono",
  "serde",
@@ -2682,7 +2696,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trycp_api"
-version = "0.0.100-alpha0"
+version = "0.17.0-dev.0"
 dependencies = [
  "serde",
  "serde_bytes",
@@ -2691,7 +2705,7 @@ dependencies = [
 
 [[package]]
 name = "trycp_client"
-version = "0.0.100-alpha0"
+version = "0.17.0-dev.0"
 dependencies = [
  "futures",
  "rmp-serde",
@@ -2703,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "trycp_server"
-version = "0.0.100-alpha0"
+version = "0.17.0-dev.0"
 dependencies = [
  "futures",
  "nix",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2180,9 +2180,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "indexmap 2.2.6",
  "itoa",
@@ -2543,15 +2543,16 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
  "num_cpus",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -2561,9 +2562,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2 1.0.81",
  "quote 1.0.36",
@@ -2680,6 +2681,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "trycp_api"
+version = "0.0.100-alpha0"
+dependencies = [
+ "serde",
+ "serde_bytes",
+ "serde_json",
+]
+
+[[package]]
+name = "trycp_client"
+version = "0.0.100-alpha0"
+dependencies = [
+ "futures",
+ "rmp-serde",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite",
+ "trycp_api",
+]
+
+[[package]]
 name = "trycp_server"
 version = "0.0.100-alpha0"
 dependencies = [
@@ -2696,6 +2718,7 @@ dependencies = [
  "structopt",
  "tokio",
  "tokio-tungstenite",
+ "trycp_api",
  "url",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,24 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
+futures = "0.3"
 hdi = "0.5.0-dev.1"
 hdk = "0.4.0-dev.1"
+nix = { version = "0.28", features = ["signal"] }
+once_cell = "1.5.0"
+parking_lot = "0.12"
+reqwest = { version = "0.12", default-features = false }
+rmp-serde = "1.1"
 serde = "1.0.192"
+serde_bytes = "0.11"
+serde_json = "1.0.117"
+slab = "0.4"
+snafu = "0.6"
+structopt = "0.2"
+tokio = "1.38"
+tokio-tungstenite = "0.21"
+trycp_api = { version = "0.17.0-dev.0", path = "crates/trycp_api" }
+url = "2"
 
 [profile.dev]
 opt-level = "z"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,7 @@
 [workspace]
 members = [
+  "crates/trycp_api",
+  "crates/trycp_client",
   "crates/trycp_server",
   "ts/test/fixture/zomes/coordinator",
   "ts/test/fixture/zomes/integrity",

--- a/crates/trycp_api/Cargo.toml
+++ b/crates/trycp_api/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "trycp_api"
-version = "0.0.100-alpha0"
+version = "0.17.0-dev.0"
 license = "CAL-1.0"
 edition = "2021"
 
 [dependencies]
-serde = { version = "1.0.192", features = ["derive"] }
-serde_bytes = "0.11"
-serde_json = "1.0.117"
+serde = { workspace = true, features = ["derive"] }
+serde_bytes = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/trycp_api/Cargo.toml
+++ b/crates/trycp_api/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "trycp_api"
+version = "0.0.100-alpha0"
+license = "CAL-1.0"
+edition = "2021"
+
+[dependencies]
+serde = { version = "1.0.192", features = ["derive"] }
+serde_bytes = "0.11"
+serde_json = "1.0.117"

--- a/crates/trycp_api/src/lib.rs
+++ b/crates/trycp_api/src/lib.rs
@@ -1,0 +1,133 @@
+#![deny(missing_docs)]
+//! Protocol for trycp_server websocket messages.
+
+/// Requests must include a message id.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct RequestWrapper {
+    /// The message id.
+    pub id: u64,
+
+    /// The request content.
+    pub request: Request,
+}
+
+/// Trycp server requests.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[serde(tag = "type")]
+pub enum Request {
+    /// Given a DNA file, stores the DNA and returns the path at which it is stored.
+    SaveDna {
+        /// This is actually the dna filename.
+        id: String,
+
+        /// Content.
+        #[serde(with = "serde_bytes")]
+        content: Vec<u8>,
+    },
+
+    /// Given a DNA URL, ensures that the DNA is downloaded and returns the path at which it is stored.
+    DownloadDna {
+        /// Url.
+        url: String,
+    },
+
+    /// Set up a player.
+    ConfigurePlayer {
+        /// The player id.
+        id: String,
+
+        /// The Holochain configuration data that is not provided by trycp.
+        ///
+        /// For example:
+        /// ```yaml
+        /// signing_service_uri: ~
+        /// encryption_service_uri: ~
+        /// decryption_service_uri: ~
+        /// dpki: ~
+        /// network: ~
+        /// ```
+        partial_config: String,
+    },
+
+    /// Start a conductor.
+    Startup {
+        /// The conductor id.
+        id: String,
+
+        /// The log level of the conductor.
+        log_level: Option<String>,
+    },
+
+    /// Shut down a conductor.
+    Shutdown {
+        /// The id of the conductor to shut down.
+        id: String,
+
+        /// The signal with which to shut down the conductor.
+        signal: Option<String>,
+    },
+
+    /// Shuts down all running conductors.
+    Reset,
+
+    /// Make an admin request.
+    CallAdminInterface {
+        /// The conductor id.
+        id: String,
+
+        /// The request.
+        #[serde(with = "serde_bytes")]
+        message: Vec<u8>,
+    },
+
+    /// Hook up an app interface.
+    ConnectAppInterface {
+        /// Token.
+        token: Vec<u8>,
+
+        /// Port.
+        port: u16,
+    },
+
+    /// Disconnect an app interface.
+    DisconnectAppInterface {
+        /// Port.
+        port: u16,
+    },
+
+    /// Make an ap request.
+    CallAppInterface {
+        /// Port.
+        port: u16,
+
+        /// The request.
+        #[serde(with = "serde_bytes")]
+        message: Vec<u8>,
+    },
+}
+
+/// A Message from a trycp_server
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[serde(tag = "type")]
+pub enum MessageToClient {
+    /// A signal emitted by a conductor.
+    Signal {
+        /// The app port from which this signal was emitted.
+        port: u16,
+
+        /// The content of the signal.
+        data: Vec<u8>,
+    },
+
+    /// A response to a trycp server request.
+    Response {
+        /// request message id.
+        id: u64,
+
+        /// message content.
+        response: std::result::Result<serde_json::Value, String>,
+    },
+}

--- a/crates/trycp_api/src/lib.rs
+++ b/crates/trycp_api/src/lib.rs
@@ -108,7 +108,29 @@ pub enum Request {
     },
 }
 
-/// A Message from a trycp_server
+/// Message response types.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[serde(untagged)]
+pub enum MessageResponse {
+    /// Unit response.
+    Null,
+
+    /// Encoded response.
+    Bytes(Vec<u8>)
+}
+
+impl MessageResponse {
+    /// Convert into bytes.
+    pub fn into_bytes(self) -> Vec<u8> {
+        match self {
+            Self::Null => Vec::new(),
+            Self::Bytes(v) => v,
+        }
+    }
+}
+
+/// A Message from a trycp_server.
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "type")]
@@ -128,6 +150,6 @@ pub enum MessageToClient {
         id: u64,
 
         /// message content.
-        response: std::result::Result<serde_json::Value, String>,
+        response: std::result::Result<MessageResponse, String>,
     },
 }

--- a/crates/trycp_client/Cargo.toml
+++ b/crates/trycp_client/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "trycp_client"
-version = "0.0.100-alpha0"
+version = "0.17.0-dev.0"
 license = "CAL-1.0"
 edition = "2021"
 
 [dependencies]
-futures = "0.3.30"
-rmp-serde = "1.1"
-serde_json = "1.0.117"
-tokio = { version = "1.38.0", features = [ "full" ] }
-tokio-tungstenite = "0.21"
-trycp_api = { version = "0.0.100-alpha0", path = "../trycp_api" }
+futures = { workspace = true }
+rmp-serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = [ "full" ] }
+tokio-tungstenite = { workspace = true }
+trycp_api = { workspace = true }

--- a/crates/trycp_client/Cargo.toml
+++ b/crates/trycp_client/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "trycp_client"
+version = "0.0.100-alpha0"
+license = "CAL-1.0"
+edition = "2021"
+
+[dependencies]
+futures = "0.3.30"
+rmp-serde = "1.1"
+serde_json = "1.0.117"
+tokio = { version = "1.38.0", features = [ "full" ] }
+tokio-tungstenite = "0.21"
+trycp_api = { version = "0.0.100-alpha0", path = "../trycp_api" }

--- a/crates/trycp_client/examples/start_stop.rs
+++ b/crates/trycp_client/examples/start_stop.rs
@@ -1,0 +1,42 @@
+use trycp_client::*;
+
+const ONE_MIN: std::time::Duration = std::time::Duration::from_secs(60);
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() {
+    let (c, _r) = TrycpClient::connect("ws://127.0.0.1:9000").await.unwrap();
+
+    c.request(Request::Reset, ONE_MIN).await.unwrap();
+
+    c.request(
+        Request::ConfigurePlayer {
+            id: "alice".to_string(),
+            partial_config: "".to_string(),
+        },
+        ONE_MIN,
+    )
+    .await
+    .unwrap();
+
+    c.request(
+        Request::Startup {
+            id: "alice".to_string(),
+            log_level: None,
+        },
+        ONE_MIN,
+    )
+    .await
+    .unwrap();
+
+    c.request(
+        Request::Shutdown {
+            id: "alice".to_string(),
+            signal: None,
+        },
+        ONE_MIN,
+    )
+    .await
+    .unwrap();
+
+    c.request(Request::Reset, ONE_MIN).await.unwrap();
+}

--- a/crates/trycp_client/src/lib.rs
+++ b/crates/trycp_client/src/lib.rs
@@ -1,0 +1,138 @@
+#![deny(missing_docs)]
+//! Trycp client.
+
+use futures::{sink::SinkExt, stream::StreamExt};
+use std::collections::HashMap;
+use std::io::Result;
+use std::sync::Arc;
+use tokio_tungstenite::{
+    tungstenite::{client::IntoClientRequest, Message},
+    *,
+};
+pub use trycp_api::Request;
+use trycp_api::*;
+
+type WsCore = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
+type WsSink = futures::stream::SplitSink<WsCore, Message>;
+type Ws = Arc<tokio::sync::Mutex<WsSink>>;
+
+/// Signal emitted from a conductor.
+pub struct Signal {
+    /// The app port from which this signal was emitted.
+    pub port: u16,
+
+    /// The content of the signal.
+    pub data: Vec<u8>,
+}
+
+/// Trycp client recv.
+pub struct SignalRecv(tokio::sync::mpsc::Receiver<Signal>);
+
+impl SignalRecv {
+    /// Receive.
+    pub async fn recv(&mut self) -> Option<Signal> {
+        self.0.recv().await
+    }
+}
+
+/// Trycp client.
+pub struct TrycpClient {
+    ws: Ws,
+    pend: Arc<
+        std::sync::Mutex<HashMap<u64, tokio::sync::oneshot::Sender<Result<serde_json::Value>>>>,
+    >,
+    recv_task: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for TrycpClient {
+    fn drop(&mut self) {
+        let ws = self.ws.clone();
+        tokio::task::spawn(async move {
+            let _ = ws.lock().await.close().await;
+        });
+        self.recv_task.abort();
+    }
+}
+
+impl TrycpClient {
+    /// Connect to a remote trycp server.
+    pub async fn connect<R>(request: R) -> Result<(Self, SignalRecv)>
+    where
+        R: IntoClientRequest + Unpin,
+    {
+        let (w, _) = tokio_tungstenite::connect_async(request)
+            .await
+            .map_err(std::io::Error::other)?;
+
+        let (sink, mut stream) = w.split();
+
+        let map: HashMap<u64, tokio::sync::oneshot::Sender<Result<serde_json::Value>>> =
+            HashMap::new();
+        let pend = Arc::new(std::sync::Mutex::new(map));
+
+        let (recv_send, recv_recv) = tokio::sync::mpsc::channel(32);
+
+        let pend2 = pend.clone();
+        let recv_task = tokio::task::spawn(async move {
+            while let Some(Ok(msg)) = stream.next().await {
+                let msg = msg.into_data();
+                let msg: MessageToClient = rmp_serde::from_slice(&msg).unwrap();
+
+                match msg {
+                    MessageToClient::Signal { port, data } => {
+                        recv_send.send(Signal { port, data }).await.unwrap();
+                    }
+                    MessageToClient::Response { id, response } => {
+                        if let Some(resp) = pend2.lock().unwrap().remove(&id) {
+                            let _ = resp.send(response.map_err(std::io::Error::other));
+                        }
+                    }
+                }
+            }
+        });
+
+        let ws = Arc::new(tokio::sync::Mutex::new(sink));
+
+        Ok((
+            Self {
+                ws,
+                pend,
+                recv_task,
+            },
+            SignalRecv(recv_recv),
+        ))
+    }
+
+    /// Make a request of the trycp server.
+    pub async fn request(
+        &self,
+        request: Request,
+        timeout: std::time::Duration,
+    ) -> Result<serde_json::Value> {
+        static RID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+        let mid = RID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        let (s, r) = tokio::sync::oneshot::channel();
+
+        self.pend.lock().unwrap().insert(mid, s);
+
+        let pend = self.pend.clone();
+        tokio::task::spawn(async move {
+            tokio::time::sleep(timeout).await;
+            pend.lock().unwrap().remove(&mid);
+        });
+
+        let request = RequestWrapper { id: mid, request };
+
+        let request = rmp_serde::to_vec_named(&request).map_err(std::io::Error::other)?;
+
+        self.ws
+            .lock()
+            .await
+            .send(Message::Binary(request))
+            .await
+            .map_err(std::io::Error::other)?;
+
+        r.await.map_err(|_| std::io::Error::other("Closed"))?
+    }
+}

--- a/crates/trycp_client/src/lib.rs
+++ b/crates/trycp_client/src/lib.rs
@@ -39,7 +39,7 @@ impl SignalRecv {
 pub struct TrycpClient {
     ws: Ws,
     pend: Arc<
-        std::sync::Mutex<HashMap<u64, tokio::sync::oneshot::Sender<Result<serde_json::Value>>>>,
+        std::sync::Mutex<HashMap<u64, tokio::sync::oneshot::Sender<Result<MessageResponse>>>>,
     >,
     recv_task: tokio::task::JoinHandle<()>,
 }
@@ -66,7 +66,7 @@ impl TrycpClient {
 
         let (sink, mut stream) = w.split();
 
-        let map: HashMap<u64, tokio::sync::oneshot::Sender<Result<serde_json::Value>>> =
+        let map: HashMap<u64, tokio::sync::oneshot::Sender<Result<MessageResponse>>> =
             HashMap::new();
         let pend = Arc::new(std::sync::Mutex::new(map));
 
@@ -108,7 +108,7 @@ impl TrycpClient {
         &self,
         request: Request,
         timeout: std::time::Duration,
-    ) -> Result<serde_json::Value> {
+    ) -> Result<MessageResponse> {
         static RID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
         let mid = RID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 

--- a/crates/trycp_server/Cargo.toml
+++ b/crates/trycp_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trycp_server"
-version = "0.0.100-alpha0"
+version = "0.17.0-dev.0"
 description = "conductor provisioner for tryorama"
 license = "CAL-1.0"
 keywords = ["holochain", "holo", "p2p", "network", "simulation"]
@@ -11,27 +11,27 @@ authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2021"
 
 [dependencies]
-futures = "0.3"
-nix = { version = "0.28", features = ["signal"] }
-once_cell = "1.5.0"
-parking_lot = "0.12"
-reqwest = { version = "0.12", default-features = false, features = [
+futures = { workspace = true }
+nix = { workspace = true, features = ["signal"] }
+once_cell = { workspace = true }
+parking_lot = { workspace = true }
+reqwest = { workspace = true, default-features = false, features = [
   "blocking",
   "json",
   "rustls-tls-native-roots",
 ] }
-rmp-serde = "1.1"
-serde = { version = "1.0.192", features = ["derive"] }
-serde_bytes = "0.11"
-slab = "0.4"
-snafu = "0.6"
-structopt = "0.2"
-tokio = { version = "1.24", features = [
+rmp-serde = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_bytes = { workspace = true }
+slab = { workspace = true }
+snafu = { workspace = true }
+structopt = { workspace = true }
+tokio = { workspace = true, features = [
   "macros",
   "rt-multi-thread",
   "process",
   "fs",
 ] }
-tokio-tungstenite = "0.21"
-trycp_api = { version = "0.0.100-alpha0", path = "../trycp_api" }
-url = "2"
+tokio-tungstenite = { workspace = true }
+trycp_api = { workspace = true }
+url = { workspace = true }

--- a/crates/trycp_server/Cargo.toml
+++ b/crates/trycp_server/Cargo.toml
@@ -33,4 +33,5 @@ tokio = { version = "1.24", features = [
   "fs",
 ] }
 tokio-tungstenite = "0.21"
+trycp_api = { version = "0.0.100-alpha0", path = "../trycp_api" }
 url = "2"

--- a/crates/trycp_server/src/app_interface.rs
+++ b/crates/trycp_server/src/app_interface.rs
@@ -26,14 +26,13 @@ pub(crate) static CONNECTIONS: Lazy<
 
 type PendingRequests = Arc<futures::lock::Mutex<Slab<u64>>>;
 
-
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case", tag = "type")]
 enum WireMessage {
     Authenticate {
         #[serde(with = "serde_bytes")]
-        data: Vec<u8>
-    }
+        data: Vec<u8>,
+    },
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -106,9 +105,14 @@ pub(crate) async fn connect(
     let listen_task = tokio::task::spawn(abortable_listen_future);
 
     // As soon as we've started listening, authenticate the connection
-    let auth_payload = rmp_serde::to_vec_named(&AppAuthenticationRequest { token }).context(SerializeAuth)?;
-    let auth_msg = rmp_serde::to_vec_named(&WireMessage::Authenticate { data: auth_payload }).context(SerializeAuth)?;
-    request_writer.send(Message::Binary(auth_msg)).await.context(WsConnect)?;
+    let auth_payload =
+        rmp_serde::to_vec_named(&AppAuthenticationRequest { token }).context(SerializeAuth)?;
+    let auth_msg = rmp_serde::to_vec_named(&WireMessage::Authenticate { data: auth_payload })
+        .context(SerializeAuth)?;
+    request_writer
+        .send(Message::Binary(auth_msg))
+        .await
+        .context(WsConnect)?;
 
     *connection = Some(Connection {
         listen_task,

--- a/crates/trycp_server/src/main.rs
+++ b/crates/trycp_server/src/main.rs
@@ -36,6 +36,7 @@ use tokio_tungstenite::{
     tungstenite::{self, Message},
     WebSocketStream,
 };
+use trycp_api::*;
 
 // NOTE: don't change without also changing in crates/holochain/src/main.rs
 const CONDUCTOR_MAGIC_STRING: &str = "Conductor ready.";
@@ -105,70 +106,6 @@ struct Player {
 struct PlayerProcesses {
     lair: Child,
     holochain: Child,
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "snake_case")]
-struct RequestWrapper {
-    id: u64,
-    request: Request,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "snake_case")]
-#[serde(tag = "type")]
-enum Request {
-    // Given a DNA file, stores the DNA and returns the path at which it is stored.
-    SaveDna {
-        id: String,
-        #[serde(with = "serde_bytes")]
-        content: Vec<u8>,
-    },
-    // Given a DNA URL, ensures that the DNA is downloaded and returns the path at which it is stored.
-    DownloadDna {
-        url: String,
-    },
-    ConfigurePlayer {
-        id: String,
-        /// The Holochain configuration data that is not provided by trycp.
-        ///
-        /// For example:
-        /// ```yaml
-        /// signing_service_uri: ~
-        /// encryption_service_uri: ~
-        /// decryption_service_uri: ~
-        /// dpki: ~
-        /// network: ~
-        /// ```
-        partial_config: String,
-    },
-    Startup {
-        id: String,
-        log_level: Option<String>,
-    },
-    Shutdown {
-        id: String,
-        signal: Option<String>,
-    },
-    // Shuts down all running conductors.
-    Reset,
-    CallAdminInterface {
-        id: String,
-        #[serde(with = "serde_bytes")]
-        message: Vec<u8>,
-    },
-    ConnectAppInterface {
-        token: Vec<u8>,
-        port: u16,
-    },
-    DisconnectAppInterface {
-        port: u16,
-    },
-    CallAppInterface {
-        port: u16,
-        #[serde(with = "serde_bytes")]
-        message: Vec<u8>,
-    },
 }
 
 fn serialize_resp<R: Serialize>(id: u64, data: R) -> Vec<u8> {


### PR DESCRIPTION
- Pulls some shared protocol types out into a trycp_api crate to be used by both the server and client.
- Adds a trycp_client crate that can be used to talk to a trycp server.