### PR TITLE
Fix WS protocol for trycp client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Removed
 ### Changed
 ### Fixed
+- The `trycp_client` now handles ping/pong messages from the TryCP server to keep the connection alive.
+- The `trycp_client` now handles the `close` event from the TryCP server to close the connection.
 
 ## 2024-05-03: v0.17.0-dev.0
 ### Changed

--- a/crates/trycp_client/src/lib.rs
+++ b/crates/trycp_client/src/lib.rs
@@ -78,8 +78,8 @@ impl TrycpClient {
         let recv_task = tokio::task::spawn(async move {
             while let Some(Ok(msg)) = stream.next().await {
                 let msg = match msg {
-                    Message::Close(_) => {
-                        eprintln!("Received websocket close from TryCP server");
+                    Message::Close(close_msg) => {
+                        eprintln!("Received websocket close from TryCP server: {}", close_msg.map(|f| f.reason).unwrap_or("No reason".into()));
                         break;
                     }
                     Message::Ping(p) => {

--- a/crates/trycp_server/src/app_interface.rs
+++ b/crates/trycp_server/src/app_interface.rs
@@ -61,7 +61,7 @@ pub(crate) async fn connect(
     port: u16,
     response_writer: Arc<futures::lock::Mutex<WsResponseWriter>>,
 ) -> Result<(), ConnectError> {
-    let connection_lock = Arc::clone(&CONNECTIONS.lock().await.entry(port).or_default());
+    let connection_lock = Arc::clone(CONNECTIONS.lock().await.entry(port).or_default());
 
     let mut connection = connection_lock.lock().await;
     if connection.is_some() {

--- a/crates/trycp_server/src/download_dna.rs
+++ b/crates/trycp_server/src/download_dna.rs
@@ -74,7 +74,7 @@ pub(crate) async fn download_dna(url_str: String) -> Result<String, DownloadDnaE
 fn get_downloaded_dna_path(url: &url::Url) -> PathBuf {
     Path::new(DNA_DIR_PATH)
         .join(url.scheme())
-        .join(url.path().replace("/", "").replace("%", "_"))
+        .join(url.path().replace('/', "").replace('%', "_"))
 }
 
 /// Tries to create a file, returning Ok(None) if a file already exists at path


### PR DESCRIPTION
Without Ping/Pong handling, the connection was being force closed by the TryCP server.

The close message has empty content which was giving me a very confusing EOF trying to deserialize from the empty vector into a response message.

Explicitly handling the WS protocol now and it's working much better