### PR TITLE
Improve error message when trycp client times out

### DIFF
--- a/crates/trycp_client/src/lib.rs
+++ b/crates/trycp_client/src/lib.rs
@@ -151,6 +151,6 @@ impl TrycpClient {
             .await
             .map_err(std::io::Error::other)?;
 
-        r.await.map_err(|_| std::io::Error::other("Closed"))?
+        r.await.map_err(|_| std::io::Error::other("Timeout"))?
     }
 }


### PR DESCRIPTION
Really minor, but I found it confusing tracing down this "Closed". The connection hasn't failed, it's just reached the timeout and the other end has been dropped.