### PR TITLE
reporting possible bug on agent_activity and installing agents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,9 +351,9 @@ checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "hdi"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2723999d284ee317d99519f8ff766279674ef167ca9329efdfaf4058e4066daa"
+checksum = "cadae6dad3be759517ff84c477987d0a4cb1788dc83eb2f18e1b9affef1f0090"
 dependencies = [
  "getrandom",
  "hdk_derive",
@@ -369,9 +369,9 @@ dependencies = [
 
 [[package]]
 name = "hdk"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862a824591fb06739fc5670ccf2633f6d06c2854e57d10ba08d968857b2bda3d"
+checksum = "addd4f6d820810334b9043dcd8d0b66f57aaffbb3497d3e4a8b4ac20662e2d3b"
 dependencies = [
  "getrandom",
  "hdi",
@@ -389,9 +389,9 @@ dependencies = [
 
 [[package]]
 name = "hdk_derive"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0191944e1b32547310d8dd132fb69a43882e2160219ad7fe338e8c30d660db3"
+checksum = "632f66b4b418d01b3fb4429c01a61d623c7d310a9fed9b8d88e2e42f354602a4"
 dependencies = [
  "darling",
  "heck",
@@ -411,9 +411,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "holo_hash"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89fbbb16e94c3d9d2f9fff8fdb2d2162c008212820dd4ace0fe54ee2e370741"
+checksum = "1c9c6d11afb2ca290e75cf1799898d5e734590591f90df5b9daa26aa66b69333"
 dependencies = [
  "base64",
  "blake2b_simd",
@@ -429,9 +429,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_integrity_types"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c6cdaa80a0a7b8e2b91e6b1ba55f8ec31db1739a5ff8158bee5ba133b99e8c"
+checksum = "857823a16e5f1be10177d8c3e77cfcf6840aeedac026b5dbbcf37e37c33e7aa8"
 dependencies = [
  "holo_hash",
  "holochain_secure_primitive",
@@ -446,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_nonce"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda29f1a4e7c6f639874d3f60f312a9cb709a1699805f206aa1a78b5ce3edae1"
+checksum = "d025b73143cee4eb2310eb5382c7946c4b2c955b9f49d71b56acb3265e5eeeb5"
 dependencies = [
  "getrandom",
  "holochain_secure_primitive",
@@ -457,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_secure_primitive"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f035101ca18ad6bac77477c71913128d6c2d349a9a624dc94cbc743ae113aa"
+checksum = "dcbfa2d79b4d35009f8870291b8d08044e60a60c35d9737ffcc8305b92674221"
 dependencies = [
  "paste",
  "serde",
@@ -493,9 +493,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_timestamp"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c621b71754f4e80152495cae35e9b867d36735d676690f35c8427ec168a5bc3a"
+checksum = "cd717aed985588905603ad45c3e91b7e39e5a7f2245bd62fa29483173901a11d"
 dependencies = [
  "chrono",
  "serde",
@@ -503,9 +503,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_util"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "283e36e7de6bb53c8d83f0ec48ba48d14481f464c32911b2c55866a597a9f057"
+checksum = "8fa9a3b7b5207aea2b65b6c56abe979f833526899af11a0c224939c61e24beb0"
 dependencies = [
  "cfg-if",
  "colored",
@@ -541,9 +541,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33027007c89c13c2fbe401a903fb05a26b896a6587e4722d29dc55c1b3bffc28"
+checksum = "04a839ffe4e692986d3ac05ee1f6c9887f5f6c96bf78fe1bdff4bf4513129b7e"
 dependencies = [
  "derive_more",
  "holo_hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-hdi = "0.6.1"
-hdk = "0.5.1"
+hdi = "0.6.2"
+hdk = "0.5.2"
 serde = "1.0.192"
 
 [profile.dev]

--- a/flake.lock
+++ b/flake.lock
@@ -53,11 +53,11 @@
     "hc-scaffold": {
       "flake": false,
       "locked": {
-        "lastModified": 1743758995,
-        "narHash": "sha256-TW5f8o3uJCf+WgPqoo676rmyGtAtUK888TnSyprK3lQ=",
+        "lastModified": 1747059984,
+        "narHash": "sha256-gRj4/ptoQ4hb3rwkZ/gX3+OhN9NmhJ42XTrOlnz6QpE=",
         "owner": "holochain",
         "repo": "scaffolding",
-        "rev": "fad2c951aa43b0a340de7cfa6149c5853e45c325",
+        "rev": "54ec9b851db94f2e9489b1cae683032f7407be84",
         "type": "github"
       },
       "original": {
@@ -70,16 +70,16 @@
     "holochain": {
       "flake": false,
       "locked": {
-        "lastModified": 1745503820,
-        "narHash": "sha256-EmV7QpUrJq/8RJg63nah1MMpQ5fRZSBI8AioCNGb1M8=",
+        "lastModified": 1746718894,
+        "narHash": "sha256-b4WCqtHxz1F8wUAUoLS9dhJgkDf+Cey1B2VbpKO6+pQ=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "6878bd2a8cdd03954a6ee954d76c1c4675fd8af9",
+        "rev": "641de8152aaa6dc9fbec7a95ff65a3a52a5e2aa1",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-0.5.1",
+        "ref": "holochain-0.5.2",
         "repo": "holochain",
         "type": "github"
       }
@@ -98,11 +98,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1746703123,
-        "narHash": "sha256-a487GXV6QJNJFfWwws5cw79Q5Acbe1zNSOojQ+Ay/zk=",
+        "lastModified": 1747071939,
+        "narHash": "sha256-sVPY2bxmtgSuvQWsU4/wNCKQL3AYclqfs41GHmXUQOY=",
         "owner": "holochain",
         "repo": "holonix",
-        "rev": "d1f35dfb2a3279cf22e0e11951c907cb1644528a",
+        "rev": "f5ce9fb759da09085fde328747f893e0fd5ff5a6",
         "type": "github"
       },
       "original": {

--- a/ts/test/fixture/zomes/coordinator/src/lib.rs
+++ b/ts/test/fixture/zomes/coordinator/src/lib.rs
@@ -1,5 +1,5 @@
 use hdk::prelude::*;
-use integrity::{Content, EntryTypes, UpdateInput};
+use integrity::{Content, EntryTypes, EntryTypesUnit, UpdateInput};
 
 #[hdk_extern]
 pub fn create(input: Content) -> ExternResult<ActionHash> {
@@ -29,6 +29,18 @@ pub fn update(input: UpdateInput) -> ExternResult<ActionHash> {
 pub fn delete(hash: ActionHash) -> ExternResult<ActionHash> {
     let deleted_hash = delete_entry(hash)?;
     Ok(deleted_hash)
+}
+
+#[hdk_extern]
+pub fn agent_activity(agent: AgentPubKey) -> ExternResult<AgentActivity> {
+    let chain = get_agent_activity(
+        agent,
+        ChainQueryFilter::new()
+            .action_type(ActionType::Create)
+            .entry_type(EntryTypesUnit::Content.try_into()?),
+        ActivityRequest::Full,
+    )?;
+    Ok(chain)
 }
 
 #[derive(Serialize, Deserialize, SerializedBytes, Debug)]

--- a/ts/test/scenario.ts
+++ b/ts/test/scenario.ts
@@ -11,160 +11,45 @@ import yaml from "js-yaml";
 import assert from "node:assert";
 import { test } from "node:test";
 import {
+  AgentApp,
   CONDUCTOR_CONFIG,
   Scenario,
   dhtSync,
+  enableAndGetAgentApp,
   getZomeCaller,
   runScenario,
 } from "../src";
 import { FIXTURE_HAPP_URL } from "./fixture";
+import { log } from "node:console";
 
 const TEST_ZOME_NAME = "coordinator";
 
-test("runScenario - Install hApp bundle and access cells through role ids", async () => {
-  await runScenario(async (scenario: Scenario) => {
-    const alice = await scenario.addPlayerWithApp({
+// todo: fix-bug: Here the addPlayersWithApps creates a new conductor and tries to install
+//      the app using the keys that were passed on this new conductor
+test("Install Agents using an already created agent_key", async () => {
+  // The wrapper takes care of creating a scenario and shutting down or deleting
+  // all conductors involved in the test scenario.
+  await runScenario(async (scenario) => {
+    // Construct proper paths for a hApp file created by the `hc app pack` command.
+    const appBundleSource: AppBundleSource = {
       type: "path",
       value: FIXTURE_HAPP_URL.pathname,
-    });
-    assert.ok(alice.namedCells.get("test"));
+    };
+    // create pub keys before installing
+    let conductor = await scenario.addConductor();
+    let alice_key = await conductor.adminWs().generateAgentPubKey();
+    let bob_key = await conductor.adminWs().generateAgentPubKey();
+
+    // Add 2 players with the test hApp to the Scenario. The returned players
+    // can be destructured.
+    const [alice, bob] = await scenario.addPlayersWithApps([
+      { appBundleSource, options: { agentPubKey: alice_key } },
+      { appBundleSource, options: { agentPubKey: bob_key } },
+    ]);
   });
 });
 
-test("runScenario - Catch error when calling non-existent zome", async () => {
-  await runScenario(async (scenario: Scenario) => {
-    const alice = await scenario.addPlayerWithApp({
-      type: "path",
-      value: FIXTURE_HAPP_URL.pathname,
-    });
-
-    await assert.rejects(
-      alice.cells[0].callZome<EntryHash>({
-        zome_name: "NOZOME",
-        fn_name: "create",
-      }),
-    );
-  });
-});
-
-test("runScenario - Catch error when attaching a protected port", async () => {
-  await runScenario(async (scenario: Scenario) => {
-    const alice = await scenario.addPlayerWithApp({
-      type: "path",
-      value: FIXTURE_HAPP_URL.pathname,
-    });
-
-    await assert.rejects(
-      alice.conductor.attachAppInterface({ port: 300, allowed_origins: "*" }),
-    );
-  });
-});
-
-test("runScenario - Catch error when calling a zome of an undefined cell", async () => {
-  await runScenario(async (scenario: Scenario) => {
-    const alice = await scenario.addPlayerWithApp({
-      type: "path",
-      value: FIXTURE_HAPP_URL.pathname,
-    });
-
-    assert.throws(() =>
-      alice.cells[2].callZome({ zome_name: "", fn_name: "" }),
-    );
-  });
-});
-
-test("runScenario - Catch error that occurs in a signal handler", async () => {
-  await runScenario(async (scenario: Scenario) => {
-    let signalHandlerAlice: SignalCb | undefined;
-    const signalReceivedAlice = new Promise<Signal>((_, reject) => {
-      signalHandlerAlice = () => {
-        reject();
-      };
-    });
-
-    const alice = await scenario.addPlayerWithApp({
-      type: "path",
-      value: FIXTURE_HAPP_URL.pathname,
-    });
-    assert.ok(signalHandlerAlice);
-    assert.ok("on" in alice.appWs);
-    alice.appWs.on("signal", signalHandlerAlice);
-
-    const signalAlice = { value: "hello alice" };
-    alice.cells[0].callZome({
-      zome_name: TEST_ZOME_NAME,
-      fn_name: "signal_loopback",
-      payload: signalAlice,
-    });
-
-    await assert.rejects(signalReceivedAlice);
-  });
-});
-
-test("Set custom network config", async () => {
-  const scenario = new Scenario();
-  const initiateIntervalMs = 10_000;
-  const minInitiateIntervalMs = 20_000;
-
-  const alice = await scenario.addPlayerWithApp(
-    {
-      type: "path",
-      value: FIXTURE_HAPP_URL.pathname,
-    },
-    { networkConfig: { initiateIntervalMs, minInitiateIntervalMs } },
-  );
-
-  const tmpDirPath = alice.conductor.getTmpDirectory();
-  const conductorConfig = yaml.load(
-    readFileSync(`${tmpDirPath}/${CONDUCTOR_CONFIG}`, { encoding: "utf-8" }),
-  );
-  assert.ok(
-    conductorConfig &&
-      typeof conductorConfig === "object" &&
-      "network" in conductorConfig,
-  );
-  const { network } = conductorConfig;
-  assert.ok(network && typeof network === "object" && "advanced" in network);
-  const { advanced } = network;
-  assert.ok(advanced && typeof advanced === "object" && "k2Gossip" in advanced);
-  const { k2Gossip } = advanced;
-  assert.ok(
-    k2Gossip &&
-      typeof k2Gossip === "object" &&
-      "initiateIntervalMs" in k2Gossip &&
-      "minInitiateIntervalMs" in k2Gossip,
-  );
-  assert.strictEqual(k2Gossip.initiateIntervalMs, initiateIntervalMs);
-  assert.strictEqual(k2Gossip.minInitiateIntervalMs, minInitiateIntervalMs);
-
-  await scenario.cleanUp();
-});
-
-test("Install hApp bundle and access cell by role name", async () => {
-  const scenario = new Scenario();
-
-  const alice = await scenario.addPlayerWithApp({
-    type: "path",
-    value: FIXTURE_HAPP_URL.pathname,
-  });
-  assert.ok(alice.namedCells.get("test"));
-  await scenario.cleanUp();
-});
-
-test("Add players with hApp bundles", async () => {
-  const scenario = new Scenario();
-  assert.ok(scenario.networkSeed);
-  const [alice, bob] = await scenario.addPlayersWithApps([
-    { appBundleSource: { type: "path", value: FIXTURE_HAPP_URL.pathname } },
-    { appBundleSource: { type: "path", value: FIXTURE_HAPP_URL.pathname } },
-  ]);
-  assert.ok(alice.namedCells.get("test"));
-  assert.ok(bob.namedCells.get("test"));
-
-  await scenario.cleanUp();
-});
-
-test("Create and read an entry, 2 conductors", async () => {
+test("Testing ability to get agent activity when agent is installed on same conductor", async () => {
   // The wrapper takes care of creating a scenario and shutting down or deleting
   // all conductors involved in the test scenario.
   await runScenario(async (scenario) => {
@@ -176,10 +61,31 @@ test("Create and read an entry, 2 conductors", async () => {
 
     // Add 2 players with the test hApp to the Scenario. The returned players
     // can be destructured.
-    const [alice, bob] = await scenario.addPlayersWithApps([
-      { appBundleSource },
-      { appBundleSource },
-    ]);
+    const custom_install = async (conductor) => {
+      // the reason I need this is because there is no way to install agents on the same conductors
+      const appInfo = await conductor.installApp(appBundleSource);
+      const adminWs = conductor.adminWs();
+      const port = await conductor.attachAppInterface();
+      const issued = await adminWs.issueAppAuthenticationToken({
+        installed_app_id: appInfo.installed_app_id,
+      });
+      const appWs = await conductor.connectAppWs(issued.token, port);
+      const agentApp: AgentApp = await enableAndGetAgentApp(
+        adminWs,
+        appWs,
+        appInfo,
+      );
+      return { conductor, appWs, ...agentApp };
+    };
+
+    let conductor = await scenario.addConductor();
+    const alice = await custom_install(conductor);
+    const bob = await custom_install(conductor);
+
+    // const [alice, bob] = await scenario.addPlayersWithApps([
+    //   { appBundleSource },
+    //   { appBundleSource },
+    // ]);
 
     // Content to be passed to the zome function that create an entry,
     const content = "Hello Tryorama";
@@ -203,239 +109,434 @@ test("Create and read an entry, 2 conductors", async () => {
       payload: createEntryHash,
     });
     assert.equal(readContent, content);
-  });
-});
 
-test("Conductor maintains data after shutdown and restart", async () => {
-  const scenario = new Scenario();
-  const appBundleSource: AppBundleSource = {
-    type: "path",
-    value: FIXTURE_HAPP_URL.pathname,
-  };
-  const [alice, bob] = await scenario.addPlayersWithApps([
-    { appBundleSource },
-    { appBundleSource },
-  ]);
-  // Get shortcut functions to call a specific zome of a specific agent
-  const aliceCaller = getZomeCaller(alice.cells[0], TEST_ZOME_NAME);
-  const bobCaller = getZomeCaller(bob.cells[0], TEST_ZOME_NAME);
-
-  const content = "Before shutdown";
-  // Use the curried function to call alice's coordinator zome
-  const createEntryHash = await aliceCaller<EntryHash>("create", content);
-
-  await dhtSync([alice, bob], alice.cells[0].cell_id[0]);
-
-  const readContent = await bobCaller<typeof content>("read", createEntryHash);
-  assert.equal(readContent, content);
-
-  await bob.conductor.shutDown();
-  assert.throws(bob.conductor.adminWs);
-
-  await bob.conductor.startUp();
-  const [appInterfaceInfo] = await bob.conductor.adminWs().listAppInterfaces();
-  const issuedBob = await bob.conductor
-    .adminWs()
-    .issueAppAuthenticationToken({ installed_app_id: bob.appId });
-  bob.appWs = await bob.conductor.connectAppWs(
-    issuedBob.token,
-    appInterfaceInfo.port,
-  );
-  const readContentAfterRestart: typeof content = await bob.appWs.callZome({
-    cell_id: bob.cells[0].cell_id,
-    zome_name: TEST_ZOME_NAME,
-    fn_name: "read",
-    payload: createEntryHash,
-  });
-  assert.equal(readContentAfterRestart, content);
-
-  await scenario.cleanUp();
-});
-
-test("Receive signals with 2 conductors", async () => {
-  const scenario = new Scenario();
-
-  let signalHandlerAlice: SignalCb | undefined;
-  const signalReceivedAlice = new Promise<AppSignal>((resolve) => {
-    signalHandlerAlice = (signal: Signal) => {
-      assert.ok(signal.type === "app");
-      resolve(signal.value);
-    };
-  });
-
-  let signalHandlerBob: SignalCb | undefined;
-  const signalReceivedBob = new Promise<AppSignal>((resolve) => {
-    signalHandlerBob = (signal: Signal) => {
-      assert.ok(signal.type === "app");
-      resolve(signal.value);
-    };
-  });
-
-  const appBundleSource: AppBundleSource = {
-    type: "path",
-    value: FIXTURE_HAPP_URL.pathname,
-  };
-  const [alice, bob] = await scenario.addPlayersWithApps([
-    { appBundleSource },
-    { appBundleSource },
-  ]);
-  assert.ok(signalHandlerAlice);
-  assert.ok("on" in alice.appWs);
-  alice.appWs.on("signal", signalHandlerAlice);
-  assert.ok(signalHandlerBob);
-  assert.ok("on" in bob.appWs);
-  bob.appWs.on("signal", signalHandlerBob);
-
-  const signalAlice = { value: "hello alice" };
-  alice.cells[0].callZome({
-    zome_name: TEST_ZOME_NAME,
-    fn_name: "signal_loopback",
-    payload: signalAlice,
-  });
-  const signalBob = { value: "hello bob" };
-  bob.cells[0].callZome({
-    zome_name: TEST_ZOME_NAME,
-    fn_name: "signal_loopback",
-    payload: signalBob,
-  });
-
-  const [actualSignalAlice, actualSignalBob] = await Promise.all([
-    signalReceivedAlice,
-    signalReceivedBob,
-  ]);
-  assert.deepEqual(actualSignalAlice.payload, signalAlice);
-  assert.deepEqual(actualSignalBob.payload, signalBob);
-
-  await scenario.cleanUp();
-});
-
-test("dhtSync - Create multiple entries, read the last, 2 conductors", async () => {
-  const scenario = new Scenario();
-
-  const appBundleSource: AppBundleSource = {
-    type: "path",
-    value: FIXTURE_HAPP_URL.pathname,
-  };
-  const [alice, bob] = await scenario.addPlayersWithApps([
-    { appBundleSource },
-    { appBundleSource },
-  ]);
-
-  // Alice creates 10 entries
-  let lastCreatedHash;
-  let lastCreatedContent;
-  for (let i = 0; i < 10; i++) {
-    lastCreatedContent = `Hi dare ${i}`;
-    lastCreatedHash = await alice.cells[0].callZome<EntryHash>({
+    const chain: any = await bob.cells[0].callZome<EntryHash>({
       zome_name: TEST_ZOME_NAME,
-      fn_name: "create",
-      payload: lastCreatedContent,
-    });
-  }
-
-  await dhtSync([alice, bob], alice.cells[0].cell_id[0]);
-
-  // Bob gets the last created entry
-  const readContent = await bob.cells[0].callZome<string>({
-    zome_name: TEST_ZOME_NAME,
-    fn_name: "read",
-    payload: lastCreatedHash,
-  });
-  assert.equal(readContent, lastCreatedContent);
-
-  await scenario.cleanUp();
-});
-
-test("dhtSync - Fails if some Ops are not synced among all conductors", async () => {
-  const scenario = new Scenario({
-    disableLocalServices: true,
-  });
-
-  const appBundleSource: AppBundleSource = {
-    type: "path",
-    value: FIXTURE_HAPP_URL.pathname,
-  };
-  const [alice, bob] = await scenario.addPlayersWithApps([
-    { appBundleSource },
-    { appBundleSource },
-  ]);
-
-  // Alice creates 1 entry
-  await alice.cells[0].callZome<EntryHash>({
-    zome_name: TEST_ZOME_NAME,
-    fn_name: "create",
-    payload: "my entry",
-  });
-
-  // Bob never receives the entry
-  try {
-    await dhtSync([alice, bob], alice.cells[0].cell_id[0]);
-    assert.fail();
-  } catch {
-    assert(true);
-  }
-
-  await scenario.cleanUp();
-});
-
-test("dhtSync - Fails if some Ops are not integrated in a conductor", async () => {
-  const scenario = new Scenario();
-
-  const appBundleSource: AppBundleSource = {
-    type: "path",
-    value: FIXTURE_HAPP_URL.pathname,
-  };
-  const [alice, bob] = await scenario.addPlayersWithApps([
-    { appBundleSource },
-    { appBundleSource },
-  ]);
-
-  // Alice creates 1 entry, but never publishes it because publishing is disabled
-  await alice.cells[0].callZome<EntryHash>({
-    zome_name: TEST_ZOME_NAME,
-    fn_name: "create",
-    payload: "my entry",
-  });
-
-  const x = true;
-  while (x) {
-    // Dump Bob's conductor state
-    const bobStateDump = await bob.conductor.adminWs().dumpFullState({
-      cell_id: alice.cells[0].cell_id,
-      dht_ops_cursor: undefined,
+      fn_name: "agent_activity",
+      payload: alice.agentPubKey,
     });
 
-    // When Bob recieves Alice's Ops, and they are being validated,
-    // then dhtSync should fail
-    if (bobStateDump.integration_dump.validation_limbo.length > 0) {
-      try {
-        // Run with a 0ms timeout, so that we check the sync status only *once*,
-        // while Bob's conductor is still in this state.
-        await dhtSync([alice], alice.cells[0].cell_id[0], 500, 0);
-        assert.fail();
-      } catch {
-        assert(true);
-      }
-      break;
-    }
-  }
-
-  await scenario.cleanUp();
-});
-
-test("runScenario - call zome by role name", async () => {
-  await runScenario(async (scenario: Scenario) => {
-    const alice = await scenario.addPlayerWithApp({
-      type: "path",
-      value: FIXTURE_HAPP_URL.pathname,
-    });
-
-    const result = (await alice.namedCells.get("test")?.callZome({
-      zome_name: "coordinator",
-      fn_name: "create",
-      payload: "hello",
-    })) as ActionHash;
-
-    assert.ok(result);
+    console.log("chain", chain);
+    // todo: this will fail right now and return 0, but it should be 1
+    assert.equal(chain.valid_activity.length, 1);
   });
 });
+
+// test("runScenario - Install hApp bundle and access cells through role ids", async () => {
+//   await runScenario(async (scenario: Scenario) => {
+//     const alice = await scenario.addPlayerWithApp({
+//       type: "path",
+//       value: FIXTURE_HAPP_URL.pathname,
+//     });
+//     assert.ok(alice.namedCells.get("test"));
+//   });
+// });
+
+// test("runScenario - Catch error when calling non-existent zome", async () => {
+//   await runScenario(async (scenario: Scenario) => {
+//     const alice = await scenario.addPlayerWithApp({
+//       type: "path",
+//       value: FIXTURE_HAPP_URL.pathname,
+//     });
+
+//     await assert.rejects(
+//       alice.cells[0].callZome<EntryHash>({
+//         zome_name: "NOZOME",
+//         fn_name: "create",
+//       }),
+//     );
+//   });
+// });
+
+// test("runScenario - Catch error when attaching a protected port", async () => {
+//   await runScenario(async (scenario: Scenario) => {
+//     const alice = await scenario.addPlayerWithApp({
+//       type: "path",
+//       value: FIXTURE_HAPP_URL.pathname,
+//     });
+
+//     await assert.rejects(
+//       alice.conductor.attachAppInterface({ port: 300, allowed_origins: "*" }),
+//     );
+//   });
+// });
+
+// test("runScenario - Catch error when calling a zome of an undefined cell", async () => {
+//   await runScenario(async (scenario: Scenario) => {
+//     const alice = await scenario.addPlayerWithApp({
+//       type: "path",
+//       value: FIXTURE_HAPP_URL.pathname,
+//     });
+
+//     assert.throws(() =>
+//       alice.cells[2].callZome({ zome_name: "", fn_name: "" }),
+//     );
+//   });
+// });
+
+// test("runScenario - Catch error that occurs in a signal handler", async () => {
+//   await runScenario(async (scenario: Scenario) => {
+//     let signalHandlerAlice: SignalCb | undefined;
+//     const signalReceivedAlice = new Promise<Signal>((_, reject) => {
+//       signalHandlerAlice = () => {
+//         reject();
+//       };
+//     });
+
+//     const alice = await scenario.addPlayerWithApp({
+//       type: "path",
+//       value: FIXTURE_HAPP_URL.pathname,
+//     });
+//     assert.ok(signalHandlerAlice);
+//     assert.ok("on" in alice.appWs);
+//     alice.appWs.on("signal", signalHandlerAlice);
+
+//     const signalAlice = { value: "hello alice" };
+//     alice.cells[0].callZome({
+//       zome_name: TEST_ZOME_NAME,
+//       fn_name: "signal_loopback",
+//       payload: signalAlice,
+//     });
+
+//     await assert.rejects(signalReceivedAlice);
+//   });
+// });
+
+// test("Set custom network config", async () => {
+//   const scenario = new Scenario();
+//   const initiateIntervalMs = 10_000;
+//   const minInitiateIntervalMs = 20_000;
+
+//   const alice = await scenario.addPlayerWithApp(
+//     {
+//       type: "path",
+//       value: FIXTURE_HAPP_URL.pathname,
+//     },
+//     { networkConfig: { initiateIntervalMs, minInitiateIntervalMs } },
+//   );
+
+//   const tmpDirPath = alice.conductor.getTmpDirectory();
+//   const conductorConfig = yaml.load(
+//     readFileSync(`${tmpDirPath}/${CONDUCTOR_CONFIG}`, { encoding: "utf-8" }),
+//   );
+//   assert.ok(
+//     conductorConfig &&
+//       typeof conductorConfig === "object" &&
+//       "network" in conductorConfig,
+//   );
+//   const { network } = conductorConfig;
+//   assert.ok(network && typeof network === "object" && "advanced" in network);
+//   const { advanced } = network;
+//   assert.ok(advanced && typeof advanced === "object" && "k2Gossip" in advanced);
+//   const { k2Gossip } = advanced;
+//   assert.ok(
+//     k2Gossip &&
+//       typeof k2Gossip === "object" &&
+//       "initiateIntervalMs" in k2Gossip &&
+//       "minInitiateIntervalMs" in k2Gossip,
+//   );
+//   assert.strictEqual(k2Gossip.initiateIntervalMs, initiateIntervalMs);
+//   assert.strictEqual(k2Gossip.minInitiateIntervalMs, minInitiateIntervalMs);
+
+//   await scenario.cleanUp();
+// });
+
+// test("Install hApp bundle and access cell by role name", async () => {
+//   const scenario = new Scenario();
+
+//   const alice = await scenario.addPlayerWithApp({
+//     type: "path",
+//     value: FIXTURE_HAPP_URL.pathname,
+//   });
+//   assert.ok(alice.namedCells.get("test"));
+//   await scenario.cleanUp();
+// });
+
+// test("Add players with hApp bundles", async () => {
+//   const scenario = new Scenario();
+//   assert.ok(scenario.networkSeed);
+//   const [alice, bob] = await scenario.addPlayersWithApps([
+//     { appBundleSource: { type: "path", value: FIXTURE_HAPP_URL.pathname } },
+//     { appBundleSource: { type: "path", value: FIXTURE_HAPP_URL.pathname } },
+//   ]);
+//   assert.ok(alice.namedCells.get("test"));
+//   assert.ok(bob.namedCells.get("test"));
+
+//   await scenario.cleanUp();
+// });
+
+// test("Create and read an entry, 2 conductors", async () => {
+//   // The wrapper takes care of creating a scenario and shutting down or deleting
+//   // all conductors involved in the test scenario.
+//   await runScenario(async (scenario) => {
+//     // Construct proper paths for a hApp file created by the `hc app pack` command.
+//     const appBundleSource: AppBundleSource = {
+//       type: "path",
+//       value: FIXTURE_HAPP_URL.pathname,
+//     };
+
+//     // Add 2 players with the test hApp to the Scenario. The returned players
+//     // can be destructured.
+//     const [alice, bob] = await scenario.addPlayersWithApps([
+//       { appBundleSource },
+//       { appBundleSource },
+//     ]);
+
+//     // Content to be passed to the zome function that create an entry,
+//     const content = "Hello Tryorama";
+
+//     // The cells of the installed hApp are returned in the same order as the DNAs
+//     // in the app manifesassert.
+//     const createEntryHash = await alice.cells[0].callZome<EntryHash>({
+//       zome_name: TEST_ZOME_NAME,
+//       fn_name: "create",
+//       payload: content,
+//     });
+
+//     // Wait for the created entry to be propagated to the other player.
+//     await dhtSync([alice, bob], alice.cells[0].cell_id[0]);
+
+//     // Using the same cell and zome as before, the second player reads the
+//     // created entry.
+//     const readContent = await bob.cells[0].callZome<typeof content>({
+//       zome_name: TEST_ZOME_NAME,
+//       fn_name: "read",
+//       payload: createEntryHash,
+//     });
+//     assert.equal(readContent, content);
+//   });
+// });
+
+// test("Conductor maintains data after shutdown and restart", async () => {
+//   const scenario = new Scenario();
+//   const appBundleSource: AppBundleSource = {
+//     type: "path",
+//     value: FIXTURE_HAPP_URL.pathname,
+//   };
+//   const [alice, bob] = await scenario.addPlayersWithApps([
+//     { appBundleSource },
+//     { appBundleSource },
+//   ]);
+//   // Get shortcut functions to call a specific zome of a specific agent
+//   const aliceCaller = getZomeCaller(alice.cells[0], TEST_ZOME_NAME);
+//   const bobCaller = getZomeCaller(bob.cells[0], TEST_ZOME_NAME);
+
+//   const content = "Before shutdown";
+//   // Use the curried function to call alice's coordinator zome
+//   const createEntryHash = await aliceCaller<EntryHash>("create", content);
+
+//   await dhtSync([alice, bob], alice.cells[0].cell_id[0]);
+
+//   const readContent = await bobCaller<typeof content>("read", createEntryHash);
+//   assert.equal(readContent, content);
+
+//   await bob.conductor.shutDown();
+//   assert.throws(bob.conductor.adminWs);
+
+//   await bob.conductor.startUp();
+//   const [appInterfaceInfo] = await bob.conductor.adminWs().listAppInterfaces();
+//   const issuedBob = await bob.conductor
+//     .adminWs()
+//     .issueAppAuthenticationToken({ installed_app_id: bob.appId });
+//   bob.appWs = await bob.conductor.connectAppWs(
+//     issuedBob.token,
+//     appInterfaceInfo.port,
+//   );
+//   const readContentAfterRestart: typeof content = await bob.appWs.callZome({
+//     cell_id: bob.cells[0].cell_id,
+//     zome_name: TEST_ZOME_NAME,
+//     fn_name: "read",
+//     payload: createEntryHash,
+//   });
+//   assert.equal(readContentAfterRestart, content);
+
+//   await scenario.cleanUp();
+// });
+
+// test("Receive signals with 2 conductors", async () => {
+//   const scenario = new Scenario();
+
+//   let signalHandlerAlice: SignalCb | undefined;
+//   const signalReceivedAlice = new Promise<AppSignal>((resolve) => {
+//     signalHandlerAlice = (signal: Signal) => {
+//       assert.ok(signal.type === "app");
+//       resolve(signal.value);
+//     };
+//   });
+
+//   let signalHandlerBob: SignalCb | undefined;
+//   const signalReceivedBob = new Promise<AppSignal>((resolve) => {
+//     signalHandlerBob = (signal: Signal) => {
+//       assert.ok(signal.type === "app");
+//       resolve(signal.value);
+//     };
+//   });
+
+//   const appBundleSource: AppBundleSource = {
+//     type: "path",
+//     value: FIXTURE_HAPP_URL.pathname,
+//   };
+//   const [alice, bob] = await scenario.addPlayersWithApps([
+//     { appBundleSource },
+//     { appBundleSource },
+//   ]);
+//   assert.ok(signalHandlerAlice);
+//   assert.ok("on" in alice.appWs);
+//   alice.appWs.on("signal", signalHandlerAlice);
+//   assert.ok(signalHandlerBob);
+//   assert.ok("on" in bob.appWs);
+//   bob.appWs.on("signal", signalHandlerBob);
+
+//   const signalAlice = { value: "hello alice" };
+//   alice.cells[0].callZome({
+//     zome_name: TEST_ZOME_NAME,
+//     fn_name: "signal_loopback",
+//     payload: signalAlice,
+//   });
+//   const signalBob = { value: "hello bob" };
+//   bob.cells[0].callZome({
+//     zome_name: TEST_ZOME_NAME,
+//     fn_name: "signal_loopback",
+//     payload: signalBob,
+//   });
+
+//   const [actualSignalAlice, actualSignalBob] = await Promise.all([
+//     signalReceivedAlice,
+//     signalReceivedBob,
+//   ]);
+//   assert.deepEqual(actualSignalAlice.payload, signalAlice);
+//   assert.deepEqual(actualSignalBob.payload, signalBob);
+
+//   await scenario.cleanUp();
+// });
+
+// test("dhtSync - Create multiple entries, read the last, 2 conductors", async () => {
+//   const scenario = new Scenario();
+
+//   const appBundleSource: AppBundleSource = {
+//     type: "path",
+//     value: FIXTURE_HAPP_URL.pathname,
+//   };
+//   const [alice, bob] = await scenario.addPlayersWithApps([
+//     { appBundleSource },
+//     { appBundleSource },
+//   ]);
+
+//   // Alice creates 10 entries
+//   let lastCreatedHash;
+//   let lastCreatedContent;
+//   for (let i = 0; i < 10; i++) {
+//     lastCreatedContent = `Hi dare ${i}`;
+//     lastCreatedHash = await alice.cells[0].callZome<EntryHash>({
+//       zome_name: TEST_ZOME_NAME,
+//       fn_name: "create",
+//       payload: lastCreatedContent,
+//     });
+//   }
+
+//   await dhtSync([alice, bob], alice.cells[0].cell_id[0]);
+
+//   // Bob gets the last created entry
+//   const readContent = await bob.cells[0].callZome<string>({
+//     zome_name: TEST_ZOME_NAME,
+//     fn_name: "read",
+//     payload: lastCreatedHash,
+//   });
+//   assert.equal(readContent, lastCreatedContent);
+
+//   await scenario.cleanUp();
+// });
+
+// test("dhtSync - Fails if some Ops are not synced among all conductors", async () => {
+//   const scenario = new Scenario({
+//     disableLocalServices: true,
+//   });
+
+//   const appBundleSource: AppBundleSource = {
+//     type: "path",
+//     value: FIXTURE_HAPP_URL.pathname,
+//   };
+//   const [alice, bob] = await scenario.addPlayersWithApps([
+//     { appBundleSource },
+//     { appBundleSource },
+//   ]);
+
+//   // Alice creates 1 entry
+//   await alice.cells[0].callZome<EntryHash>({
+//     zome_name: TEST_ZOME_NAME,
+//     fn_name: "create",
+//     payload: "my entry",
+//   });
+
+//   // Bob never receives the entry
+//   try {
+//     await dhtSync([alice, bob], alice.cells[0].cell_id[0]);
+//     assert.fail();
+//   } catch {
+//     assert(true);
+//   }
+
+//   await scenario.cleanUp();
+// });
+
+// test("dhtSync - Fails if some Ops are not integrated in a conductor", async () => {
+//   const scenario = new Scenario();
+
+//   const appBundleSource: AppBundleSource = {
+//     type: "path",
+//     value: FIXTURE_HAPP_URL.pathname,
+//   };
+//   const [alice, bob] = await scenario.addPlayersWithApps([
+//     { appBundleSource },
+//     { appBundleSource },
+//   ]);
+
+//   // Alice creates 1 entry, but never publishes it because publishing is disabled
+//   await alice.cells[0].callZome<EntryHash>({
+//     zome_name: TEST_ZOME_NAME,
+//     fn_name: "create",
+//     payload: "my entry",
+//   });
+
+//   const x = true;
+//   while (x) {
+//     // Dump Bob's conductor state
+//     const bobStateDump = await bob.conductor.adminWs().dumpFullState({
+//       cell_id: alice.cells[0].cell_id,
+//       dht_ops_cursor: undefined,
+//     });
+
+//     // When Bob recieves Alice's Ops, and they are being validated,
+//     // then dhtSync should fail
+//     if (bobStateDump.integration_dump.validation_limbo.length > 0) {
+//       try {
+//         // Run with a 0ms timeout, so that we check the sync status only *once*,
+//         // while Bob's conductor is still in this state.
+//         await dhtSync([alice], alice.cells[0].cell_id[0], 500, 0);
+//         assert.fail();
+//       } catch {
+//         assert(true);
+//       }
+//       break;
+//     }
+//   }
+
+//   await scenario.cleanUp();
+// });
+
+// test("runScenario - call zome by role name", async () => {
+//   await runScenario(async (scenario: Scenario) => {
+//     const alice = await scenario.addPlayerWithApp({
+//       type: "path",
+//       value: FIXTURE_HAPP_URL.pathname,
+//     });
+
+//     const result = (await alice.namedCells.get("test")?.callZome({
+//       zome_name: "coordinator",
+//       fn_name: "create",
+//       payload: "hello",
+//     })) as ActionHash;
+
+//     assert.ok(result);
+//   });
+// });


### PR DESCRIPTION
### Summary
- Tests that show bugs
  - When I install 2 agents on the same conductor and try to `get_agent_activity `, it returns Empty
  - When I use `addPlayersWithApps` and pass a pubkey as an option, it fails to install
    - The reason most likely is because it is trying to install on a newly created conductor instead of the conductor that the key was originally added to 

### TODO:
- [ ] CHANGELOG mentions all code changes.
- [ ] docs have been updated (`npm run build && git add docs`)
