### PR TITLE
chore: release v0.19.0-dev.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Removed
 ### Changed
 ### Fixed
-- Fixed the logic in `dhtSync` to determine whether conductors are in sync ([#287](https://github.com/holochain/tryorama/pull/287))
+
+## 2025-09-09: v0.19.0-dev.1
+
+### Fixed
 - Upgrade all dependencies to Holochain v0.6.
+
+## 2025-09-03: v0.19.0-dev.0
+
+### Fixed
+- Fixed the logic in `dhtSync` to determine whether conductors are in sync ([#287](https://github.com/holochain/tryorama/pull/287))
 
 ## 2025-05-23: v0.18.2
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@holochain/tryorama",
-  "version": "0.19.0-dev.0",
+  "version": "0.19.0-dev.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@holochain/tryorama",
-      "version": "0.19.0-dev.0",
+      "version": "0.19.0-dev.1",
       "license": "MIT",
       "dependencies": {
         "@holochain/client": "^0.20.0-dev.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@holochain/tryorama",
   "description": "Toolset to manage Holochain conductors and facilitate running test scenarios",
-  "version": "0.19.0-dev.0",
+  "version": "0.19.0-dev.1",
   "author": "Holochain Foundation",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
### Summary


### TODO:
- [x] CHANGELOG mentions all code changes.
- [x] docs have been updated (`npm run build && git add docs`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated changelog with a new 0.19.0-dev.1 entry.
  - Reorganized previous notes: moved the dhtSync fix into a 0.19.0-dev.0 section.
  - Noted upgrade alignment with Holochain v0.6 in the latest entry.

- Chores
  - Bumped version to 0.19.0-dev.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->